### PR TITLE
Allow different codeowner roots

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Orta Therox
+Copyright (c) 2019-Present Orta Therox
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ packages/typescriptlang-org/src/copy/es/**/*.ts @KingDarBoja [translate] [es]
 packages/documentation/copy/es/**/*.ts @KingDarBoja [translate] [es]
 ```
 
+## Config
+
+There is only one option available ATM, `cwd` which can be used to determine the root folder to look for CODEOWNER files in:
+
+```yml
+- name: Run Codeowners merge check
+  uses:  orta/code-owner-self-merge@v1
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with: 
+    cwd: './docs'
+```
+
 ### Dev
 
 Use `npx jest --watch` to run tests.

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,11 @@ branding:
   icon: git-merge
   color: purple
 
+inputs:
+  cwd:
+    description: 'The path to the root folder where it should look for code owners'
+    default: ''
+
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const {readFileSync} = require("fs")
 
 // Effectively the main function
 async function run() {
-  core.info("Running version 1.4.1")
+  core.info("Running version 1.4.2")
 
   // Tell folks they can merge
   if (context.eventName === "pull_request_target") {
@@ -26,7 +26,7 @@ async function commentOnMergablePRs() {
   }
   
   // Setup
-  const cwd = process.cwd()
+  const cwd = core.getInput('cwd') || process.cwd()
   const octokit = getOctokit(process.env.GITHUB_TOKEN)
   const pr = context.payload.pull_request
   const thisRepo = { owner: context.repo.owner, repo: context.repo.repo }
@@ -97,7 +97,7 @@ async function mergeIfLGTMAndHasAccess() {
   }
   
   // Setup
-  const cwd = process.cwd()
+  const cwd = core.getInput('cwd') || process.cwd()
   const octokit = getOctokit(process.env.GITHUB_TOKEN)
   const thisRepo = { owner: context.repo.owner, repo: context.repo.repo }
   const issue = context.payload.issue || context.payload.pull_request


### PR DESCRIPTION
If this is to work on DT, then it needs to be able to have a separate lookup for the CODEOWNERS file because the existing one is already in use.